### PR TITLE
Ajuste relative_url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ subtitle: Resolvendo problemas do mundo real
 description: 
   Canal DevOps é um blog que tem como objetivo difundir o conhecimento, técnicas e boas práticas. Focando em problemas do mundo real.
 
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/canaldevops-preview" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 logo_file: logo.png  # your profile image 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ subtitle: Resolvendo problemas do mundo real
 description: 
   Canal DevOps é um blog que tem como objetivo difundir o conhecimento, técnicas e boas práticas. Focando em problemas do mundo real.
 
-baseurl: "{{ '/canaldevops-preview' }}" # the subpath of your site, e.g. /blog
+baseurl: "/canaldevops-preview" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 logo_file: logo.png  # your profile image 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ subtitle: Resolvendo problemas do mundo real
 description: 
   Canal DevOps é um blog que tem como objetivo difundir o conhecimento, técnicas e boas práticas. Focando em problemas do mundo real.
 
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "{{ '/canaldevops-preview' }}" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 logo_file: logo.png  # your profile image 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ subtitle: Resolvendo problemas do mundo real
 description: 
   Canal DevOps é um blog que tem como objetivo difundir o conhecimento, técnicas e boas práticas. Focando em problemas do mundo real.
 
-baseurl: "/canaldevops-preview" # the subpath of your site, e.g. /blog
+#baseurl: "/canaldevops-preview" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 logo_file: logo.png  # your profile image 

--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ subtitle: Resolvendo problemas do mundo real
 description: 
   Canal DevOps é um blog que tem como objetivo difundir o conhecimento, técnicas e boas práticas. Focando em problemas do mundo real.
 
-baseurl: "/canaldevops-preview" # the subpath of your site, e.g. /blog
+baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 logo_file: logo.png  # your profile image 

--- a/_config_preview.yml
+++ b/_config_preview.yml
@@ -1,0 +1,1 @@
+baseurl: "/canaldevops-preview"

--- a/_includes/level_card.html
+++ b/_includes/level_card.html
@@ -4,7 +4,7 @@
         {% for level in site.levels %}
         <div id="#level{{ level.key }}"></div>
         <li class="tag-head"> 
-            <a href="/levels/{{ level.key }}">{{ level.key }} - {{ level.name }}</a> 
+            <a href="{{ '/levels/' | append: level.key | relative_url }}">{{ level.key }} - {{ level.name }}</a> 
         </li>
         <a name="level{{ level.key }}"></a>
         {% endfor %}        

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -11,7 +11,7 @@ layout: default
                 {% for author in site.authors %}
                 <br />
                 <div class="row">
-                    <div class="col-md-2"> <img src="/assets/img/author/{{ author.profilephoto }}" class="company-logo" /> </div>
+                    <div class="col-md-2"> <img src="{{ '/assets/img/author/' | append: author.profilephoto | relative_url }}" class="company-logo" /> </div>
                     <div class="col-md-6">
                         <h4 class="experience-title">{{ author.name }}</h4>
                         <p class="experience-desc">{{ author.bio }}</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,7 @@
             <div class="col-lg-12">
                 <div class="row">
                     <div class="col-md-2 center">
-                        <a href="/"> <img src="/assets/img/{{ site.logo_file }}" class="profile-img"> </a>
+                        <a href="{{ '/' | relative_url }}"> <img src="{{ '/assets/img/' | append: site.logo_file | relative_url }}" class="profile-img"> </a>
                     </div>  
                     <div class="col-md-4">
                         <h1 class="profile-name">{{ site.title }}</h1>
@@ -39,8 +39,8 @@
                     </div>
                     <div class="col-md-6 center">
                         <ul class="nav justify-content-end" id="navigation">
-                            <li class="nav-item"> <a class="nav-link" href="/">Home</a> </li>
-                            <li class="nav-item"> <a class="nav-link" href="/authors">Autores</a> </li>                            
+                            <li class="nav-item"> <a class="nav-link" href="{{ '/' | relative_url }}">Home</a> </li>
+                            <li class="nav-item"> <a class="nav-link" href="{{ '/authors' | relative_url }}">Autores</a> </li>                            
                         </ul>
                     </div>
                 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <!-- Site Description -->
     <meta name="description" content="{{ site.description }}">
     <!-- Stylesheets goes here -->
-    <link rel="stylesheet" href="{{ \"/assets/css/main.css\" | relative_url }}" />
+    <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
     <!-- Favicon -->
     <link rel="icon" href="/assets/img/favicon.ico" type="image/gif" sizes="16x16">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <!-- Site Description -->
     <meta name="description" content="{{ site.description }}">
     <!-- Stylesheets goes here -->
-    <link rel="stylesheet" href="{{ \"/assets/css/main.cs\s\" | relative_url }} />
+    <link rel="stylesheet" href="{{ \"/assets/css/main.css\" | relative_url }}" />
     <!-- Favicon -->
     <link rel="icon" href="/assets/img/favicon.ico" type="image/gif" sizes="16x16">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <!-- Site Description -->
     <meta name="description" content="{{ site.description }}">
     <!-- Stylesheets goes here -->
-    <link rel="stylesheet" href={{ "/assets/css/main.css" | relative_url }} />
+    <link rel="stylesheet" href="{{ \"/assets/css/main.cs\s\" | relative_url }} />
     <!-- Favicon -->
     <link rel="icon" href="/assets/img/favicon.ico" type="image/gif" sizes="16x16">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <!-- Site Description -->
     <meta name="description" content="{{ site.description }}">
     <!-- Stylesheets goes here -->
-    <link rel="stylesheet" href="/assets/css/main.css" />
+    <link rel="stylesheet" href={{ "/assets/css/main.css" | | relative_url }} />
     <!-- Favicon -->
     <link rel="icon" href="/assets/img/favicon.ico" type="image/gif" sizes="16x16">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <!-- Site Description -->
     <meta name="description" content="{{ site.description }}">
     <!-- Stylesheets goes here -->
-    <link rel="stylesheet" href={{ "/assets/css/main.css" | | relative_url }} />
+    <link rel="stylesheet" href={{ "/assets/css/main.css" | relative_url }} />
     <!-- Favicon -->
     <link rel="icon" href="/assets/img/favicon.ico" type="image/gif" sizes="16x16">
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,7 +15,7 @@ layout: default
                         <div class="card-body center"> <img src="/assets/img/author/{{ author.profilephoto }}" class="author-profile-img">
                             <h4 class="card-title">{{ post.title }}</h4>
                             <h6 class="card-subtitle mb-2 text-muted">{{ post.date | date: "%d/%m/%Y"}}</h6>
-                            <p class="card-text">{{ post.excerpt }}</p> <a href="{{ post.url }}" data-disqus-identifier="{{ post.url }}" class="btn btn-primary btn-lg">Ler</a> <span class="disqus-comment-count" data-disqus-identifier="{{ post.url }}"></span> </div>
+                            <p class="card-text">{{ post.excerpt }}</p> <a href="{{ post.url | relative_url }}" data-disqus-identifier="{{ post.url }}" class="btn btn-primary btn-lg">Ler</a> <span class="disqus-comment-count" data-disqus-identifier="{{ post.url }}"></span> </div>
                     </div>
 
                 {% endfor %}   

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,7 +11,7 @@ layout: default
                 {% for post in site.posts %}
                 {% assign author = site.authors | where: 'username', post.author | first %}
 
-                    <div class="card blog-post"> <img class="card-img-top" src="/assets/img/{{ post.thumbnail }}" alt="{{ post.title }}">
+                    <div class="card blog-post"> <img class="card-img-top" src="{{ '/assets/img/' + post.thumbnail | relative_url }}" alt="{{ post.title }}">
                         <div class="card-body center"> <img src="/assets/img/author/{{ author.profilephoto }}" class="author-profile-img">
                             <h4 class="card-title">{{ post.title }}</h4>
                             <h6 class="card-subtitle mb-2 text-muted">{{ post.date | date: "%d/%m/%Y"}}</h6>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,8 +11,8 @@ layout: default
                 {% for post in site.posts %}
                 {% assign author = site.authors | where: 'username', post.author | first %}
 
-                    <div class="card blog-post"> <img class="card-img-top" src="{{ '/assets/img/' + post.thumbnail | relative_url }}" alt="{{ post.title }}">
-                        <div class="card-body center"> <img src="/assets/img/author/{{ author.profilephoto }}" class="author-profile-img">
+                    <div class="card blog-post"> <img class="card-img-top" src="{{ '/assets/img/' | append: post.thumbnail | relative_url }}" alt="{{ post.title }}">
+                        <div class="card-body center"> <img src="{{ '/assets/img/author/' | append: author.profilephoto | relative_url }}" class="author-profile-img">
                             <h4 class="card-title">{{ post.title }}</h4>
                             <h6 class="card-subtitle mb-2 text-muted">{{ post.date | date: "%d/%m/%Y"}}</h6>
                             <p class="card-text">{{ post.excerpt }}</p> <a href="{{ post.url | relative_url }}" data-disqus-identifier="{{ post.url }}" class="btn btn-primary btn-lg">Ler</a> <span class="disqus-comment-count" data-disqus-identifier="{{ post.url }}"></span> </div>

--- a/_layouts/level.html
+++ b/_layouts/level.html
@@ -12,11 +12,11 @@ layout: default
                 {% for post in posts %}
                 {% assign author = site.authors | where: 'username', post.author | first %}
 
-                    <div class="card blog-post"> <img class="card-img-top" src="/assets/img/{{ post.thumbnail }}" alt="{{ post.title }}">
-                        <div class="card-body center"> <img src="/assets/img/author/{{ author.profilephoto }}" class="author-profile-img">
+                    <div class="card blog-post"> <img class="card-img-top" src="{{ '/assets/img/' | append: post.thumbnail | relative_url }}" alt="{{ post.title }}">
+                        <div class="card-body center"> <img src="{{ '/assets/img/author/' | append: author.profilephoto | relative_url }}" class="author-profile-img">
                             <h4 class="card-title">{{ post.title }}</h4>
                             <h6 class="card-subtitle mb-2 text-muted">{{ post.date }}</h6>
-                            <p class="card-text">{{ post.excerpt }}</p> <a href="{{ post.url }}" data-disqus-identifier="{{ post.url }}" class="btn btn-primary btn-lg">Ler</a> <span class="disqus-comment-count" data-disqus-identifier="{{ post.url }}"></span> </div>
+                            <p class="card-text">{{ post.excerpt }}</p> <a href="{{ post.url | relative_url }}" data-disqus-identifier="{{ post.url }}" class="btn btn-primary btn-lg">Ler</a> <span class="disqus-comment-count" data-disqus-identifier="{{ post.url }}"></span> </div>
                     </div>
 
                 {% endfor %}   

--- a/_layouts/level.html
+++ b/_layouts/level.html
@@ -15,7 +15,7 @@ layout: default
                     <div class="card blog-post"> <img class="card-img-top" src="{{ '/assets/img/' | append: post.thumbnail | relative_url }}" alt="{{ post.title }}">
                         <div class="card-body center"> <img src="{{ '/assets/img/author/' | append: author.profilephoto | relative_url }}" class="author-profile-img">
                             <h4 class="card-title">{{ post.title }}</h4>
-                            <h6 class="card-subtitle mb-2 text-muted">{{ post.date }}</h6>
+                            <h6 class="card-subtitle mb-2 text-muted">{{ post.date | date: "%d/%m/%Y"  }}</h6>
                             <p class="card-text">{{ post.excerpt }}</p> <a href="{{ post.url | relative_url }}" data-disqus-identifier="{{ post.url }}" class="btn btn-primary btn-lg">Ler</a> <span class="disqus-comment-count" data-disqus-identifier="{{ post.url }}"></span> </div>
                     </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,13 +11,13 @@ layout: default
 			<article class="card" itemscope itemtype="http://schema.org/BlogPosting">
 				<div class="card-header">
 					<h2 class="post-meta">{{ page.title }}</h2>
-					<p class="post-summary">Publicado por : <img src="/assets/img/author/{{ author.profilephoto }}" class="author-profile-img"> <span itemprop="author" itemscope itemtype="http://schema.org/Person"> <span itemprop="name">{{ author.name }}</span> </span> em
+					<p class="post-summary">Publicado por : <img src="{{ '/assets/img/author/' | append: author.profilephoto | relative_url }}" class="author-profile-img"> <span itemprop="author" itemscope itemtype="http://schema.org/Person"> <span itemprop="name">{{ author.name }}</span> </span> em
 						<time datetime="{{ page.date }}" itemprop="datePublished">{{ page.date | date: "%d/%m/%Y" }}</time>
 					</p>
-					<div class="post-categories"> Nível : <a href="/levels/{{ page.level }}">{{ level.key }} - {{ level.name}}</a> </div>
+					<div class="post-categories"> Nível : <a href="{{ '/levels/' | append: page.level | relative_url }}">{{ level.key }} - {{ level.name}}</a> </div>
 				</div>
 				<div class="card-body" itemprop="articleBody"> 
-                    <img class="card-img-top" src="/assets/img/{{ page.thumbnail }}" alt="">
+                    <img class="card-img-top" src="{{ '/assets/img/' | append: page.thumbnail | relative_url }}" alt="">
 
                     {{ content }}
                     


### PR DESCRIPTION
Eu ajustei as URLs para poder usar a variável `relative_url` pq assim eu consigo rodar o site no minha conta pra facilitar o preview de alterações sem bagunçar com o site principal.

Eu tb estou [comentando a config baseurl](https://github.com/canaldevops/canaldevops.github.io/commit/662a80836b41a7e6731093a71f40c8bf90ddb57f) pq setando vazio estava sobreescrevendo o valor que o github seta nela. Espero que isso não quebre nada no site original.

Desculpa a quantidade de commits é pq eu estava editando as páginas direto no github :/ sorry A gente pode fazer um squash na hora do merge.

Você pode checar se tem algo quebrado [aqui](https://soeirosantos.github.io/canaldevops-preview/).

Vlwws